### PR TITLE
Store: en ny måte å jobbe med kohorter og dokumenter

### DIFF
--- a/draft/mikrobloggeriet/teodor/api2/store.clj
+++ b/draft/mikrobloggeriet/teodor/api2/store.clj
@@ -13,7 +13,7 @@
 (def olorm
   (sorted-map
    :cohort/root "o"
-   :cohort/id :olorm
+   :cohort/slug "olorm"
    :cohort/members [{:author/email "git@teod.eu", :author/first-name "Teodor"}
                     {:author/email "lars.barlindhaug@iterate.no", :author/first-name "Lars"}
                     {:author/email "oddmunds@iterate.no", :author/first-name "Oddmund"}
@@ -22,7 +22,7 @@
 (def jals
   (sorted-map
    :cohort/root "j"
-   :cohort/id :jals
+   :cohort/slug "jals"
    :cohort/members [{:author/email "aaberg89@gmail.com", :author/first-name "Jørgen"}
                     {:author/email "adrian.tofting@iterate.no",
                      :author/first-name "Adrian"}
@@ -32,21 +32,17 @@
 (def oj
   (sorted-map
    :cohort/root "text/oj"
-   :cohort/id :oj
+   :cohort/slug "oj"
    :cohort/members [{:author/first-name "Johan"}
                     {:author/first-name "Olav"}]))
 
 (def genai
   (sorted-map
    :cohort/root "text/genai"
-   :cohort/id :genai
+   :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def cohorts
-  (->> [olorm jals oj genai]
-       (map (fn [c]
-              [(:cohort/id c) c]))
-       (into (sorted-map))))
+(def cohorts [olorm jals oj genai])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; HELPERS

--- a/src/mikrobloggeriet/cohort.clj
+++ b/src/mikrobloggeriet/cohort.clj
@@ -4,6 +4,36 @@
    [babashka.fs :as fs]
    [mikrobloggeriet.doc :as doc]))
 
+(comment
+  ;; example cohort:
+  (sorted-map
+   :cohort/root "text/oj"
+   :cohort/slug "oj"
+   :cohort/members [{:author/first-name "Johan"}
+                    {:author/first-name "Olav"}])
+  )
+
+;; This namespace contains no constructors.
+;; See store.clj for available cohorts.
+
+(defn slug [cohort]
+  (or
+   (:cohort/slug cohort)
+   ;; TODO: delete this branch, present for backwards compatibility
+   (when-let [cohort-id (:cohort/id cohort)]
+     (clojure.core/name cohort-id))))
+
+(defn root [cohort]
+  (:cohort/root cohort))
+
+(defn members [cohort]
+  (:cohort/members cohort))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; DEPRECATED
+;;
+;; Cohorts are now found in mikrobloggeriet.store.
+
 (def
   ^:deprecated
   olorm
@@ -76,16 +106,3 @@
                    {:doc/slug (fs/file-name f)}))
             (filter (partial doc/exists? cohort))
             (sort-by doc/number))))))
-
-(comment
-  ;; jals documents
-  (docs jals)
-
-  ;; all documents
-  (docs)
-  )
-
-
-(defn slug [cohort]
-  (when-let [id (:cohort/id cohort)]
-    (clojure.core/name id)))

--- a/src/mikrobloggeriet/doc.clj
+++ b/src/mikrobloggeriet/doc.clj
@@ -14,7 +14,24 @@
 ;; in order to take the object first.
 ;; I think this will help make threading easier.
 
-(defn exists? [cohort doc]
+(defn from-slug [slug]
+  {:doc/slug slug})
+
+(defn slug [doc]
+  (:doc/slug doc))
+
+(defn number [doc]
+  (when-let [slug (:doc/slug doc)]
+    (parse-long (last (str/split slug #"-")))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; DEPRECATED FUNCTIONS
+;;
+;; Do not use!
+
+(defn
+  ^:deprecated
+  exists? [cohort doc]
   (and (:cohort/root cohort)
        (:doc/slug doc)
        (fs/directory? (fs/file (:cohort/root cohort)
@@ -26,19 +43,19 @@
                             (:doc/slug doc)
                             "index.md"))))
 
-(defn href
+(defn
+ ^:deprecated
+  href
   "Create a link to a doc in a cohort"
   [cohort doc]
   (when (and (:cohort/id cohort)
              (:doc/slug doc))
     (str "/" (name (:cohort/id cohort)) "/" (:doc/slug doc))))
 
-(defn index-md-path [cohort doc]
+(defn
+  ^:deprecated
+  index-md-path [cohort doc]
   (when (exists? cohort doc)
     (fs/file (:cohort/root cohort)
              (:doc/slug doc)
              "index.md")))
-
-(defn number [doc]
-  (when-let [slug (:doc/slug doc)]
-    (parse-long (last (str/split slug #"-")))))

--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -1,4 +1,8 @@
-(ns mikrobloggeriet.store)
+(ns mikrobloggeriet.store
+  (:require
+   [babashka.fs :as fs]
+   [mikrobloggeriet.cohort :as cohort]
+   [mikrobloggeriet.doc :as doc]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; KNOWN COHORTS
@@ -6,7 +10,7 @@
 (def olorm
   (sorted-map
    :cohort/root "o"
-   :cohort/id :olorm
+   :cohort/slug "olorm"
    :cohort/members [{:author/email "git@teod.eu", :author/first-name "Teodor"}
                     {:author/email "lars.barlindhaug@iterate.no", :author/first-name "Lars"}
                     {:author/email "oddmunds@iterate.no", :author/first-name "Oddmund"}
@@ -15,7 +19,7 @@
 (def jals
   (sorted-map
    :cohort/root "j"
-   :cohort/id :jals
+   :cohort/slug "jals"
    :cohort/members [{:author/email "aaberg89@gmail.com", :author/first-name "Jørgen"}
                     {:author/email "adrian.tofting@iterate.no",
                      :author/first-name "Adrian"}
@@ -25,18 +29,58 @@
 (def oj
   (sorted-map
    :cohort/root "text/oj"
-   :cohort/id :oj
+   :cohort/slug "oj"
    :cohort/members [{:author/first-name "Johan"}
                     {:author/first-name "Olav"}]))
 
 (def genai
   (sorted-map
    :cohort/root "text/genai"
-   :cohort/id :genai
+   :cohort/slug "genai"
    :cohort/members [{:author/first-name "Julian"}]))
 
-(def cohorts
-  (->> [olorm jals oj genai]
-       (map (fn [c]
-              [(:cohort/id c) c]))
-       (into (sorted-map))))
+(def cohorts [olorm jals oj genai])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; HELPERS
+
+(defn doc-exists? [cohort doc]
+  (and (cohort/root cohort)
+       (doc/slug doc)
+       (fs/directory? (fs/file (cohort/root cohort)
+                               (doc/slug doc)))
+       (fs/exists? (fs/file (cohort/root cohort)
+                            (doc/slug doc)
+                            "meta.edn"))
+       (fs/exists? (fs/file (cohort/root cohort)
+                            (:doc/slug doc)
+                            "index.md"))))
+
+(defn doc-md-path [cohort doc]
+  (when (doc-exists? cohort doc)
+    (fs/file (cohort/root cohort)
+             (doc/slug doc)
+             "index.md")))
+
+(defn cohort-href [cohort]
+  (when (cohort/slug cohort)
+    (str "/" (cohort/slug cohort)
+         "/")))
+
+(defn doc-href [cohort doc]
+  (when (and (cohort/slug cohort)
+             (doc/slug doc))
+    (str "/" (cohort/slug cohort)
+         "/" (doc/slug doc)
+         "/")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; LIST DOCUMENTS
+
+(defn docs [cohort]
+  (let [root (cohort/root cohort)]
+    (when (and root (fs/directory? root))
+      (->> (fs/list-dir (fs/file root))
+           (map (comp doc/from-slug fs/file-name))
+           (filter (partial doc-exists? cohort))
+           (sort-by doc/number)))))


### PR DESCRIPTION
Denne PR-en:

1. Flytter `mikrobloggeriet.store` inn fra draft til selve koden
2. Implementerer en ny måte å hente ut dokumenter og kohorter
3. Beholder gamle implementasjoner i `cohort` og `doc` - men deprekerer funksjoner vi nå heller bør bruke fra `store`.