### PR TITLE
Legge til route til feed uten "trailing slash"

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -482,6 +482,7 @@
   (GET "/genai/:slug/" req (doc (assoc req
                                        :mikrobloggeriet/cohort cohort/genai
                                        :mikrobloggeriet.doc/slug (get-in req [:route-params :slug]))))
+  (GET "/feed" req (rss-feed))
   (GET "/feed/" req (rss-feed))
   )
 


### PR DESCRIPTION
Slik at vi kan bruke både `https://mikrobloggeriet.no/feed/` og `https://mikrobloggeriet.no/feed`.