### PR TITLE
`mblog create`: give sane error messages when config is missing.

### DIFF
--- a/src/mikrobloggeriet/cli.clj
+++ b/src/mikrobloggeriet/cli.clj
@@ -273,7 +273,7 @@ Allowed options:
       (println "was not found on your system. You must be able to use your configured editor to
 edit files from a terminal. For example:")
       (println)
-      (println (str "    $ " editor "yourfile.txt"))
+      (println (str "    $ " editor " yourfile.txt"))
       (println)
       (println "If that command crashes," editor "can't be used as an editor.")
       (println "To learn how to configure your editor, run `mblog config -h`.")


### PR DESCRIPTION
I stedet for å kaste en feil når det mangler config, prøver vi å fortelle brukeren hva som har gått galt, og hvordan brukeren kan fikse problemet.

```
$ # feilhåndtering før når config mangler
$ mblog create --dry-run
----- Error --------------------------------------------------------------------
Type:     java.lang.AssertionError
Message:  Assert failed: dir
Location: /Users/teodorlu/dev/iterate/mikrobloggeriet/src/mikrobloggeriet/cli.clj:259:10

----- Context ------------------------------------------------------------------
255:           :git.user/email (git-user-email ".")
256:           :cohort-id (config-get :cohort)
257:           :draft (or (:draft opts) false)}
258:          create-opts->commands
259:          (map command-transform)
              ^--- Assert failed: dir
260:          execute!))
261:   )
262: 
263: (defn mblog-links
264:   [opts+args]

----- Stack trace --------------------------------------------------------------
clojure.core/map             - <built-in>
mikrobloggeriet.cli/execute! - /Users/teodorlu/dev/iterate/mikrobloggeriet/src/mikrobloggeriet/cli.clj:259:10
mikrobloggeriet.cli/execute! - /Users/teodorlu/dev/iterate/mikrobloggeriet/src/mikrobloggeriet/cli.clj:197:1
mikrobloggeriet.cli          - /Users/teodorlu/dev/iterate/mikrobloggeriet/src/mikrobloggeriet/cli.clj:251:5
mikrobloggeriet.cli          - /Users/teodorlu/dev/iterate/mikrobloggeriet/src/mikrobloggeriet/cli.clj:291:3
clojure.core/apply           - <built-in>
user                         - <expr>:1:44

$ # feilhåndtering etter når config mangler
$ # husk å bytte til rett branch!
$ git switch mblog-create-error-handling 
Switched to branch 'mblog-create-error-handling'
$ mblog create --dry-run                
Property missing: :editor. To learn how to add it, run `mblog config -h`.
Property missing: :cohort. To learn how to add it, run `mblog config -h`.
Property missing: :repo-path. To learn how to add it, run `mblog config -h`.
```