### PR TITLE
RSS-items bør ha guid

### DIFF
--- a/src/mikrobloggeriet/serve.clj
+++ b/src/mikrobloggeriet/serve.clj
@@ -82,6 +82,7 @@
               :pubDate (->java-time-instant (read-created-date (store/doc-meta-path cohort doc)))
               :category (cohort/slug cohort)
               :description slug
+              :guid slug
               "content:encoded" (str
                                  "<![CDATA["
                                  (:doc-html (markdown->html+info (slurp (store/doc-md-path cohort doc))))


### PR DESCRIPTION
[validator.w3.org](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fmikrobloggeriet.no%2Ffeed%2F) synes at vi burde ha GUIDs på _itemsene_ i RSS-feed.

Det synes _theorangeone_ også https://theorangeone.net/posts/rss-guids/

Heldigvis er det en kjapp endring. Jeg foreslår å bruke _slug_, dvs feks `olorm-21`, `jals-90`, osv. som GUID.