### PR TITLE
Julians E-post

### DIFF
--- a/src/mikrobloggeriet/store.clj
+++ b/src/mikrobloggeriet/store.clj
@@ -45,7 +45,8 @@
    :cohort/root "text/luke"
    :cohort/slug "luke"
    :cohort/members [{:author/email "jomarn@me.com" :author/first-name "Johan"} 
-                    {:author/email "haavard@vaage.com" :author/first-name "Håvard"}]))
+                    {:author/email "haavard@vaage.com" :author/first-name "Håvard"}
+                    {:author/email "julian.hallen.eriksen@iterate.no" :author/first-name "Julian"}]))
 
 (def cohorts (sorted-map :olorm olorm :jals jals :oj oj :genai genai :luke luke))
 


### PR DESCRIPTION
LUKE-oversikten viser ikke at det er Julian som har skrevet:

<img width="948" alt="image" src="https://github.com/user-attachments/assets/508e3a71-c74a-4da6-b096-a2d32ab41903">

Ser ut som vi mangler E-post og navn for julian i `mikrobloggeriet.cohort/luke`.