### PR TITLE
Urlog load ascii and create seperate components

### DIFF
--- a/src/mikrobloggeriet/urlog.clj
+++ b/src/mikrobloggeriet/urlog.clj
@@ -28,7 +28,6 @@
 (defn logo->html [logo]
   [:pre {:class :logo :aria-label "URLOG logo ascii art"} logo])
 
-
 (defn door-paths [doors-dir]
   (->> (fs/list-dir doors-dir)
        (map str)
@@ -47,7 +46,7 @@
   (logo->html (:logo load-ascii-assets))
   (wall->html (:wall load-ascii-assets))
   (let [door (first (:doors load-ascii-assets))]
-    (door+url->html door ""))
+    (door+url->html door "example.com"))
   (rand-nth (:doors load-ascii-assets)))
 
 (def urlogfile-path "text/urlog/urls.edn")
@@ -71,8 +70,8 @@
         "Tilfeldige dører til internettsteder som kan være morsomme og/eller interessante å besøke en eller annen gang."]]
       [:div {:class :all-doors}
        (for [doc (reverse (:urlog/docs urlog-data))]
-         (let [url (:urlog/url doc)
-               door (rand-nth (:doors assets))]
+         (let [door (rand-nth (:doors assets))
+               url (:urlog/url doc)]
            [:div {:class :wall :role :none}
             (wall->html (:wall assets))
             (door+url->html door url)


### PR DESCRIPTION
Prøvde meg på å separere logikk for filinnlasting fra HTML-komponentene.

Nå skjer innlasting av alle urlog ascii assets i en `load-ascii`-funksjon.
Hver HTML-komponent tar inn ascii-strengen(ene) den skal vise som argumenter.

Det gjenstår nok litt opprydding i funksjonsnavn og struktur, før jeg skal begynne å se på å separere logikk i egne namespaces.
Videre er det ganske uoversiktelig logikk i `page` fortsatt. Spesielt rundt å velge en random dør, og reversering osv.
Jeg tror også CSSen bør ryddes litt opp i.

Tar gjerne tilbakemeldingner på datastrukturen til `load-ascii`!

