### PR TITLE
mblog.sh: styling to stderr

### DIFF
--- a/mblog.sh
+++ b/mblog.sh
@@ -78,10 +78,12 @@ uuid4() {
 
 fail() {
     [ -t 1 ] && notty=false || notty=true
+    {
     $notty || printf '\033[31m' # red
     # shellcheck disable=SC2059 # be careful with %
-    printf >&2 "$@"
+    printf "$@"
     $notty || printf '\033[m' # reset
+    } >&2
     return 1
 }
 


### PR DESCRIPTION
* 0b0dfb4 mblog.sh: styling to stderr
function `fail` printed ANSI color codes to stdout
and error message to stderr.

print them all to stderr.

Mini-endring. Vanligvis ser man ingen forskjell fordi stdout og stderr sendes til terminalen i forventet rekkefølge, men det hadde man ingen garanti for.